### PR TITLE
Use ; as a separator character instead of ,

### DIFF
--- a/sql/select_stops_as_csv.sql
+++ b/sql/select_stops_as_csv.sql
@@ -12,4 +12,4 @@ COPY (
         source.nimi_ru as swedish_name,
         'digiroad_r' as external_stop_source
     FROM :schema.dr_pysakki source
-) TO STDOUT WITH (FORMAT CSV, HEADER)
+) TO STDOUT WITH (FORMAT CSV, DELIMITER ';', HEADER)


### PR DESCRIPTION
This commit ensures that Jore4 importer and the stop
export script uses the same CSV separator character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-digiroad-import/21)
<!-- Reviewable:end -->
