### PR TITLE
Include Digiroad links with linkkityyp=7 ("Levähdysalue")

### DIFF
--- a/sql/transform_dr_linkki.sql
+++ b/sql/transform_dr_linkki.sql
@@ -43,7 +43,7 @@ WHERE
         4, -- Moottoriliikennetien osa
         5, -- Kiertoliittymän osa
         6, -- Ramppi
-    --  7, -- Levähdysalue
+        7, -- Levähdysalue
     --  8, -- Pyörätie tai yhdistetty pyörätie ja jalkakäytävä
     --  9, -- Jalankulkualueen osa, esim. kävelykatu tai jalkakäytävä
     -- 10, -- Huolto- tai pelastustien osa


### PR DESCRIPTION
The national IDs of some Digiroad stops located along such infrastructure links appear as ELY number of some Jore3 scheduled stop points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-digiroad-import/30)
<!-- Reviewable:end -->
