### PR TITLE
Refactor shell scripts into a more concise form

### DIFF
--- a/create_qgis_project_archive.sh
+++ b/create_qgis_project_archive.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Create a zip archive containing HSL QGIS fixup project.
-mkdir -p $WORK_DIR/zip  
+mkdir -p "$WORK_DIR"/zip
+
 zip -r "${WORK_DIR}/zip/$(date "+%Y-%m-%d")_hsl_qgis_fixup_project.zip" \
   fixup/jore4-digiroad-fix-project.qgz \
   fixup/digiroad workdir/shp/UUSIMAA/

--- a/export_infra_network_csv.sh
+++ b/export_infra_network_csv.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -23,4 +23,4 @@ docker_exec postgres "exec $PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_
 docker_exec postgres "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_infra_network_csv.sh
+++ b/export_infra_network_csv.sh
@@ -4,13 +4,13 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start $DOCKER_CONTAINER_NAME
+docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL to start.
-docker exec "${DOCKER_CONTAINER_NAME}" sh -c "$PG_WAIT_LOCAL"
+docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
 
 # Export CSV file to output directory.
 OUTPUT_FILENAME="infra_network_digiroad.csv"
@@ -22,8 +22,8 @@ mkdir -p "$OUTPUT_FOLDER"
 docker exec "$DOCKER_CONTAINER_NAME" sh -c \
   "$PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
 
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${CWD}/sql:/tmp/sql -v ${OUTPUT_FOLDER}:/tmp/csv ${DOCKER_IMAGE} \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=${DB_SCHEMA_NAME_DIGIROAD} -o /tmp/csv/${OUTPUT_FILENAME}"
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql -v "$OUTPUT_FOLDER":/tmp/csv "$DOCKER_IMAGE" \
+  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
-docker stop $DOCKER_CONTAINER_NAME
+docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_infra_network_csv.sh
+++ b/export_infra_network_csv.sh
@@ -20,10 +20,10 @@ mkdir -p "$OUTPUT_FOLDER"
 
 # Make sure infrastructure links are updated.
 docker exec "$DOCKER_CONTAINER_NAME" sh -c \
-  "$PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_IMPORT_SCHEMA_NAME}.dr_linkki_fixup;\""
+  "$PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
 
 docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${CWD}/sql:/tmp/sql -v ${OUTPUT_FOLDER}:/tmp/csv ${DOCKER_IMAGE} \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=${DB_IMPORT_SCHEMA_NAME} -o /tmp/csv/${OUTPUT_FILENAME}"
+  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=${DB_SCHEMA_NAME_DIGIROAD} -o /tmp/csv/${OUTPUT_FILENAME}"
 
 # Stop Docker container.
 docker stop $DOCKER_CONTAINER_NAME

--- a/export_infra_network_csv.sh
+++ b/export_infra_network_csv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -10,7 +10,7 @@ source "$(dirname "$0")/set_env_vars.sh"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 # Export CSV file to output directory.
 OUTPUT_FILENAME="infra_network_digiroad.csv"
@@ -18,9 +18,9 @@ OUTPUT_FILENAME="infra_network_digiroad.csv"
 mkdir -p "${WORK_DIR}/csv"
 
 # Make sure infrastructure links are updated.
-$DOCKER_EXEC_POSTGRES "exec $PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
+docker_exec postgres "exec $PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
 
-$DOCKER_EXEC_POSTGRES "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
+docker_exec postgres "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_infra_network_csv.sh
+++ b/export_infra_network_csv.sh
@@ -9,21 +9,18 @@ source "$(dirname "$0")/set_env_vars.sh"
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 # Export CSV file to output directory.
 OUTPUT_FILENAME="infra_network_digiroad.csv"
-OUTPUT_FOLDER="${WORK_DIR}/csv"
 
-mkdir -p "$OUTPUT_FOLDER"
+mkdir -p "${WORK_DIR}/csv"
 
 # Make sure infrastructure links are updated.
-docker exec "$DOCKER_CONTAINER_NAME" sh -c \
-  "$PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
+$DOCKER_EXEC_POSTGRES "exec $PSQL -nt -c \"REFRESH MATERIALIZED VIEW ${DB_SCHEMA_NAME_DIGIROAD}.dr_linkki_fixup;\""
 
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql -v "$OUTPUT_FOLDER":/tmp/csv "$DOCKER_IMAGE" \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
+$DOCKER_EXEC_POSTGRES "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_infra_links_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_mbtiles_dr_linkki.sh
+++ b/export_mbtiles_dr_linkki.sh
@@ -28,25 +28,23 @@ MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 # Start Docker container. The container is expected to exist and contain required database table to be exported.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 # Export pg_dump file from database.
-time docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$SHP_OUTPUT_DIR"/:/tmp/shp "$DOCKER_IMAGE" \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+time $DOCKER_EXEC_HOSTUSER "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 
 rm -f "${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE"
-time docker run --rm -v "$SHP_OUTPUT_DIR"/:/tmp/shp -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/geojson/$GEOJSON_OUTPUT_FILE /tmp/shp/$SHP_OUTPUT_FILE"
+time $DOCKER_EXEC_HOSTUSER \
+  "exec ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE /tmp/mbtiles/shp_input/$SHP_OUTPUT_FILE"
 
 # Convert from GeoJSON to MBTiles.
 
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}"
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
-docker run --rm -v "$MBTILES_OUTPUT_DIR"/:/tmp/mbtiles -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
-  sh -c "tippecanoe /tmp/geojson/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f; mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
+$DOCKER_EXEC_HOSTUSER "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_mbtiles_dr_linkki.sh
+++ b/export_mbtiles_dr_linkki.sh
@@ -35,7 +35,7 @@ PGSQL2SHP='pgsql2shp -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_T
 
 # Export pg_dump file from database.
 time docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${SHP_OUTPUT_DIR}/:/tmp/shp $DOCKER_IMAGE \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_MBTILES_SCHEMA_NAME}.${DB_TABLE_NAME}"
+  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 

--- a/export_mbtiles_dr_linkki.sh
+++ b/export_mbtiles_dr_linkki.sh
@@ -31,11 +31,9 @@ docker start "$DOCKER_CONTAINER_NAME"
 # Wait for PostgreSQL to start.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
 
-PGSQL2SHP="pgsql2shp -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -u digiroad"
-
 # Export pg_dump file from database.
 time docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$SHP_OUTPUT_DIR"/:/tmp/shp "$DOCKER_IMAGE" \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 

--- a/export_mbtiles_dr_linkki.sh
+++ b/export_mbtiles_dr_linkki.sh
@@ -26,7 +26,7 @@ GEOJSON_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.geojson"
 MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 
 # Start Docker container. The container is expected to exist and contain required database table to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -47,4 +47,4 @@ rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
 docker_exec "$CURRUSER" "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_mbtiles_dr_linkki.sh
+++ b/export_mbtiles_dr_linkki.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -29,22 +29,22 @@ MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 # Export pg_dump file from database.
-time $DOCKER_EXEC_HOSTUSER "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+time docker_exec "$CURRUSER" "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 
 rm -f "${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE"
-time $DOCKER_EXEC_HOSTUSER \
+time docker_exec "$CURRUSER" \
   "exec ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE /tmp/mbtiles/shp_input/$SHP_OUTPUT_FILE"
 
 # Convert from GeoJSON to MBTiles.
 
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}"
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
-$DOCKER_EXEC_HOSTUSER "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
+docker_exec "$CURRUSER" "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -26,7 +26,7 @@ GEOJSON_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.geojson"
 MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 
 # Start Docker container. The container is expected to exist and contain required database table to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -46,4 +46,4 @@ rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
 docker_exec "$CURRUSER" "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -31,11 +31,9 @@ docker start "$DOCKER_CONTAINER_NAME"
 # Wait for PostgreSQL to start.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
 
-PGSQL2SHP="pgsql2shp -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -u digiroad"
-
 # Export pg_dump file from database.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$SHP_OUTPUT_DIR"/:/tmp/shp "$DOCKER_IMAGE" \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -28,25 +28,22 @@ MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 # Start Docker container. The container is expected to exist and contain required database table to be exported.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 # Export pg_dump file from database.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$SHP_OUTPUT_DIR"/:/tmp/shp "$DOCKER_IMAGE" \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+$DOCKER_EXEC_HOSTUSER "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 
 rm -f "${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE"
-docker run --rm -v "$SHP_OUTPUT_DIR"/:/tmp/shp -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/geojson/$GEOJSON_OUTPUT_FILE /tmp/shp/$SHP_OUTPUT_FILE"
+$DOCKER_EXEC_HOSTUSER "exec ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE /tmp/mbtiles/shp_input/$SHP_OUTPUT_FILE"
 
 # Convert from GeoJSON to MBTiles.
 
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}"
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
-docker run --rm -v "$MBTILES_OUTPUT_DIR"/:/tmp/mbtiles -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
-  sh -c "tippecanoe /tmp/geojson/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f; mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
+$DOCKER_EXEC_HOSTUSER "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -35,7 +35,7 @@ PGSQL2SHP='pgsql2shp -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_T
 
 # Export pg_dump file from database.
 docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${SHP_OUTPUT_DIR}/:/tmp/shp $DOCKER_IMAGE \
-  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_MBTILES_SCHEMA_NAME}.${DB_TABLE_NAME}"
+  sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 DB_TABLE_NAME="dr_pysakki"
 
@@ -26,29 +26,29 @@ GEOJSON_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.geojson"
 MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 
 # Start Docker container. The container is expected to exist and contain required database table to be exported.
-docker start $DOCKER_CONTAINER_NAME
+docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL to start.
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
 
-PGSQL2SHP='pgsql2shp -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -u digiroad'
+PGSQL2SHP="pgsql2shp -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -u digiroad"
 
 # Export pg_dump file from database.
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${SHP_OUTPUT_DIR}/:/tmp/shp $DOCKER_IMAGE \
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$SHP_OUTPUT_DIR"/:/tmp/shp "$DOCKER_IMAGE" \
   sh -c "$PGSQL2SHP -f /tmp/shp/${SHP_OUTPUT_FILE} digiroad ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 
-rm -f ${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE || true
-docker run --rm -v ${SHP_OUTPUT_DIR}/:/tmp/shp -v ${GEOJSON_OUTPUT_DIR}:/tmp/geojson ${DOCKER_IMAGE} \
+rm -f "${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE"
+docker run --rm -v "$SHP_OUTPUT_DIR"/:/tmp/shp -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
   sh -c "ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/geojson/$GEOJSON_OUTPUT_FILE /tmp/shp/$SHP_OUTPUT_FILE"
 
 # Convert from GeoJSON to MBTiles.
 
-rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}" || true
-rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal" || true
-docker run --rm -v ${MBTILES_OUTPUT_DIR}/:/tmp/mbtiles -v ${GEOJSON_OUTPUT_DIR}:/tmp/geojson ${DOCKER_IMAGE} \
+rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}"
+rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
+docker run --rm -v "$MBTILES_OUTPUT_DIR"/:/tmp/mbtiles -v "$GEOJSON_OUTPUT_DIR":/tmp/geojson "$DOCKER_IMAGE" \
   sh -c "tippecanoe /tmp/geojson/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f; mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
-docker stop $DOCKER_CONTAINER_NAME
+docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_mbtiles_dr_pysakki.sh
+++ b/export_mbtiles_dr_pysakki.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -29,21 +29,21 @@ MBTILES_OUTPUT_FILE="${OUTPUT_FILE_BASENAME}.mbtiles"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 # Export pg_dump file from database.
-$DOCKER_EXEC_HOSTUSER "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
+docker_exec "$CURRUSER" "exec $PGSQL2SHP -f /tmp/mbtiles/shp_input/${SHP_OUTPUT_FILE} ${DB_NAME} ${DB_SCHEMA_NAME_MBTILES}.${DB_TABLE_NAME}"
 
 # Convert from Shapefile to GeoJSON.
 
 rm -f "${GEOJSON_OUTPUT_DIR}/$GEOJSON_OUTPUT_FILE"
-$DOCKER_EXEC_HOSTUSER "exec ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE /tmp/mbtiles/shp_input/$SHP_OUTPUT_FILE"
+docker_exec "$CURRUSER" "exec ogr2ogr --config SHAPE_ENCODING $SHP_ENCODING -f GeoJSON -lco COORDINATE_PRECISION=7 /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE /tmp/mbtiles/shp_input/$SHP_OUTPUT_FILE"
 
 # Convert from GeoJSON to MBTiles.
 
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}"
 rm -f "${MBTILES_OUTPUT_DIR}/${MBTILES_OUTPUT_FILE}-journal"
-$DOCKER_EXEC_HOSTUSER "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
+docker_exec "$CURRUSER" "tippecanoe /tmp/mbtiles/geojson_input/$GEOJSON_OUTPUT_FILE -o /tmp/$MBTILES_OUTPUT_FILE -z$MBTILES_MAX_ZOOM_LEVEL -X -l $MBTILES_LAYER_NAME -n \"$MBTILES_DESCRIPTION\" -f && exec mv /tmp/$MBTILES_OUTPUT_FILE /tmp/mbtiles/$MBTILES_OUTPUT_FILE"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_pgdump_digiroad.sh
+++ b/export_pgdump_digiroad.sh
@@ -14,7 +14,7 @@ docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres $DOCKER_IMAGE sh -c "
 
 PGDUMP_OUTPUT="digiroad_r_$(date "+%Y-%m-%d").pgdump"
 OUTPUT_TABLES="dr_linkki dr_pysakki dr_kaantymisrajoitus"
-OUTPUT_TABLE_OPTIONS="`echo ${OUTPUT_TABLES[@]} | sed \"s/dr_/-t ${DB_IMPORT_SCHEMA_NAME}.dr_/g\"`"
+OUTPUT_TABLE_OPTIONS="`echo ${OUTPUT_TABLES[@]} | sed \"s/dr_/-t ${DB_SCHEMA_NAME_DIGIROAD}.dr_/g\"`"
 
 mkdir -p ${WORK_DIR}/pgdump
 

--- a/export_pgdump_digiroad.sh
+++ b/export_pgdump_digiroad.sh
@@ -4,23 +4,23 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start $DOCKER_CONTAINER_NAME
+docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL to start.
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres $DOCKER_IMAGE sh -c "$PG_WAIT"
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres "$DOCKER_IMAGE" sh -c "$PG_WAIT"
 
 PGDUMP_OUTPUT="digiroad_r_$(date "+%Y-%m-%d").pgdump"
 OUTPUT_TABLES="dr_linkki dr_pysakki dr_kaantymisrajoitus"
-OUTPUT_TABLE_OPTIONS="`echo ${OUTPUT_TABLES[@]} | sed \"s/dr_/-t ${DB_SCHEMA_NAME_DIGIROAD}.dr_/g\"`"
+OUTPUT_TABLE_OPTIONS=$(echo "${OUTPUT_TABLES[@]}" | sed "s/dr_/-t ${DB_SCHEMA_NAME_DIGIROAD}.dr_/g")
 
-mkdir -p ${WORK_DIR}/pgdump
+mkdir -p "$WORK_DIR"/pgdump
 
 # Export pg_dump file.
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${WORK_DIR}/pgdump/:/tmp/pgdump $DOCKER_IMAGE \
-  sh -c "$PG_DUMP -Fc --clean -f /tmp/pgdump/${PGDUMP_OUTPUT} $OUTPUT_TABLE_OPTIONS"
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$WORK_DIR"/pgdump/:/tmp/pgdump "$DOCKER_IMAGE" \
+  sh -c "$PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
 
 # Stop Docker container.
-docker stop $DOCKER_CONTAINER_NAME
+docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_pgdump_digiroad.sh
+++ b/export_pgdump_digiroad.sh
@@ -9,8 +9,8 @@ source "$(dirname "$0")/set_env_vars.sh"
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres "$DOCKER_IMAGE" sh -c "$PG_WAIT"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 PGDUMP_OUTPUT="digiroad_r_$(date "+%Y-%m-%d").pgdump"
 OUTPUT_TABLES="dr_linkki dr_pysakki dr_kaantymisrajoitus"
@@ -19,8 +19,7 @@ OUTPUT_TABLE_OPTIONS=$(echo "${OUTPUT_TABLES[@]}" | sed "s/dr_/-t ${DB_SCHEMA_NA
 mkdir -p "$WORK_DIR"/pgdump
 
 # Export pg_dump file.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$WORK_DIR"/pgdump/:/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "$PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
+$DOCKER_EXEC_HOSTUSER "exec $PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_pgdump_digiroad.sh
+++ b/export_pgdump_digiroad.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -10,7 +10,7 @@ source "$(dirname "$0")/set_env_vars.sh"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 PGDUMP_OUTPUT="digiroad_r_$(date "+%Y-%m-%d").pgdump"
 OUTPUT_TABLES="dr_linkki dr_pysakki dr_kaantymisrajoitus"
@@ -19,7 +19,7 @@ OUTPUT_TABLE_OPTIONS=$(echo "${OUTPUT_TABLES[@]}" | sed "s/dr_/-t ${DB_SCHEMA_NA
 mkdir -p "$WORK_DIR"/pgdump
 
 # Export pg_dump file.
-$DOCKER_EXEC_HOSTUSER "exec $PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
+docker_exec "$CURRUSER" "exec $PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_pgdump_digiroad.sh
+++ b/export_pgdump_digiroad.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -22,4 +22,4 @@ mkdir -p "$WORK_DIR"/pgdump
 docker_exec "$CURRUSER" "exec $PG_DUMP -Fc --clean -f /tmp/pgdump/$PGDUMP_OUTPUT $OUTPUT_TABLE_OPTIONS"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_routing_schema.sh
+++ b/export_routing_schema.sh
@@ -12,12 +12,11 @@ source "$(dirname "$0")/set_env_vars.sh"
 # populated from shapefiles.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 # Create routing schema. pgRouting topology is created as well.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql "$DOCKER_IMAGE" \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/routing/create_routing_schema.sql -v source_schema=$DB_SCHEMA_NAME_DIGIROAD -v schema=$DB_SCHEMA_NAME_ROUTING"
+$DOCKER_EXEC_POSTGRES "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/routing/create_routing_schema.sql -v source_schema=$DB_SCHEMA_NAME_DIGIROAD -v schema=$DB_SCHEMA_NAME_ROUTING"
 
 DUMP_DIR="${WORK_DIR}/pgdump"
 DUMP_FILE_BASENAME="$(date "+%Y-%m-%d")_create_routing_schema_digiroad_r"
@@ -30,35 +29,31 @@ mkdir -p "$DUMP_DIR"
 # profile of map-matching backend where database migration scripts are bypassed.
 # All the table definitions are created and data populated in one shot based on
 # this dump.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "$PG_DUMP --clean --if-exists --no-owner -f /tmp/pgdump/$SQL_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
+$DOCKER_EXEC_HOSTUSER "exec $PG_DUMP --clean --if-exists --no-owner -f /tmp/pgdump/$SQL_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
 
 # Add the license text at the beginning of the plain-language SQL dump, because
 # the data contained in the dump is derived from Digiroad's open data. Add text
 # starting at line 5 so that it doesn't interfere with GitHub workflows, which
 # determine the file type from the first few lines.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "\
+$DOCKER_EXEC_HOSTUSER "\
 sed '5i\
 -- Digiroad data has been licensed with Creative Commons BY 4.0 license by the\\
 -- Finnish Transport Infrastructure Agency:\\
 --  https://vayla.fi/en/transport-network/data/digiroad/data\\
-' /tmp/pgdump/$SQL_OUTPUT > temp.sql && mv temp.sql /tmp/pgdump/$SQL_OUTPUT
+' /tmp/pgdump/$SQL_OUTPUT > /tmp/temp.sql && exec mv /tmp/temp.sql /tmp/pgdump/$SQL_OUTPUT
 "
 
 # Export the entire routing schema (with data) as a dump file in PostgreSQL's
 # custom format. With custom format, the restoration of schema and/or table
 # data items can be selectively filtered and applied by passing a toc list
 # (table of contents) file as an argument to `pg_restore` command.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "$PG_DUMP --format=c --clean --no-owner -f /tmp/pgdump/$PGDUMP_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
+$DOCKER_EXEC_HOSTUSER "exec $PG_DUMP --format=c --clean --no-owner -f /tmp/pgdump/$PGDUMP_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
 
 # Dump a toc list file (for the generated pg_dump file) that lists the items
 # contained in the dump file. The list can be edited by re-ordering or
 # removing items that are not intended to be restored. That makes it possible
 # to e.g. restore data only for selected database tables.
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "pg_restore --list \"/tmp/pgdump/${PGDUMP_OUTPUT}\" --file=\"/tmp/pgdump/${PGDUMP_OUTPUT}.list\""
+$DOCKER_EXEC_HOSTUSER "exec pg_restore --list \"/tmp/pgdump/${PGDUMP_OUTPUT}\" --file=\"/tmp/pgdump/${PGDUMP_OUTPUT}.list\""
 
 # Derive additional toc lists for restoring data (and only data) for selected
 # tables. The additional tocs are created with current deployment scenarios of

--- a/export_routing_schema.sh
+++ b/export_routing_schema.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/set_env_vars.sh"
 #
 # The container is expected to exist and contain Digiroad schema with data
 # populated from shapefiles.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -61,4 +61,4 @@ docker_exec "$CURRUSER" "exec pg_restore --list \"/tmp/pgdump/${PGDUMP_OUTPUT}\"
 "$CWD"/util/create_additional_pgdump_tocs.sh "${DUMP_DIR}/${PGDUMP_OUTPUT}"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_routing_schema.sh
+++ b/export_routing_schema.sh
@@ -17,7 +17,7 @@ docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
 
 # Create routing schema. pgRouting topology is created as well.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql "$DOCKER_IMAGE" \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/routing/create_routing_schema.sql -v source_schema=$DB_IMPORT_SCHEMA_NAME -v schema=$DB_ROUTING_SCHEMA_NAME"
+  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/routing/create_routing_schema.sql -v source_schema=$DB_SCHEMA_NAME_DIGIROAD -v schema=$DB_SCHEMA_NAME_ROUTING"
 
 DUMP_DIR="${WORK_DIR}/pgdump"
 DUMP_FILE_BASENAME="$(date "+%Y-%m-%d")_create_routing_schema_digiroad_r"
@@ -31,7 +31,7 @@ mkdir -p "$DUMP_DIR"
 # All the table definitions are created and data populated in one shot based on
 # this dump.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "$PG_DUMP --clean --if-exists --no-owner -f /tmp/pgdump/$SQL_OUTPUT --schema=$DB_ROUTING_SCHEMA_NAME"
+  sh -c "$PG_DUMP --clean --if-exists --no-owner -f /tmp/pgdump/$SQL_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
 
 # Add the license text at the beginning of the plain-language SQL dump, because
 # the data contained in the dump is derived from Digiroad's open data. Add text
@@ -51,7 +51,7 @@ sed '5i\
 # data items can be selectively filtered and applied by passing a toc list
 # (table of contents) file as an argument to `pg_restore` command.
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgdump "$DOCKER_IMAGE" \
-  sh -c "$PG_DUMP --format=c --clean --no-owner -f /tmp/pgdump/$PGDUMP_OUTPUT --schema=$DB_ROUTING_SCHEMA_NAME"
+  sh -c "$PG_DUMP --format=c --clean --no-owner -f /tmp/pgdump/$PGDUMP_OUTPUT --schema=$DB_SCHEMA_NAME_ROUTING"
 
 # Dump a toc list file (for the generated pg_dump file) that lists the items
 # contained in the dump file. The list can be edited by re-ordering or

--- a/export_routing_schema.sh
+++ b/export_routing_schema.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container.
 #
@@ -63,7 +63,7 @@ docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$DUMP_DIR":/tmp/pgd
 # Derive additional toc lists for restoring data (and only data) for selected
 # tables. The additional tocs are created with current deployment scenarios of
 # map-matching Docker image taken into account.
-${CWD}/util/create_additional_pgdump_tocs.sh "${DUMP_DIR}/${PGDUMP_OUTPUT}"
+"$CWD"/util/create_additional_pgdump_tocs.sh "${DUMP_DIR}/${PGDUMP_OUTPUT}"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_stops_csv.sh
+++ b/export_stops_csv.sh
@@ -16,7 +16,7 @@ docker exec "${DOCKER_CONTAINER_NAME}" sh -c "$PG_WAIT_LOCAL"
 OUTPUT_FILENAME="digiroad_stops.csv"
 mkdir -p ${WORK_DIR}/csv
 docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${CWD}/sql:/tmp/sql -v ${WORK_DIR}/csv:/tmp/csv ${DOCKER_IMAGE} \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=${DB_IMPORT_SCHEMA_NAME} -o /tmp/csv/${OUTPUT_FILENAME}"
+  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=${DB_SCHEMA_NAME_DIGIROAD} -o /tmp/csv/${OUTPUT_FILENAME}"
 
 # Stop Docker container.
 docker stop $DOCKER_CONTAINER_NAME

--- a/export_stops_csv.sh
+++ b/export_stops_csv.sh
@@ -4,19 +4,21 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start $DOCKER_CONTAINER_NAME
+docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL to start.
-docker exec "${DOCKER_CONTAINER_NAME}" sh -c "$PG_WAIT_LOCAL"
+docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
 
 # Export csv file to output directory.
 OUTPUT_FILENAME="digiroad_stops.csv"
-mkdir -p ${WORK_DIR}/csv
-docker run --rm --link "${DOCKER_CONTAINER_NAME}":postgres -v ${CWD}/sql:/tmp/sql -v ${WORK_DIR}/csv:/tmp/csv ${DOCKER_IMAGE} \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=${DB_SCHEMA_NAME_DIGIROAD} -o /tmp/csv/${OUTPUT_FILENAME}"
+
+mkdir -p "$WORK_DIR"/csv
+
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql -v "$WORK_DIR"/csv:/tmp/csv "$DOCKER_IMAGE" \
+  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
-docker stop $DOCKER_CONTAINER_NAME
+docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_stops_csv.sh
+++ b/export_stops_csv.sh
@@ -9,16 +9,15 @@ source "$(dirname "$0")/set_env_vars.sh"
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
 docker start "$DOCKER_CONTAINER_NAME"
 
-# Wait for PostgreSQL to start.
-docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"
+# Wait for PostgreSQL server to be ready.
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
 # Export csv file to output directory.
 OUTPUT_FILENAME="digiroad_stops.csv"
 
 mkdir -p "$WORK_DIR"/csv
 
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/sql:/tmp/sql -v "$WORK_DIR"/csv:/tmp/csv "$DOCKER_IMAGE" \
-  sh -c "$PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
+$DOCKER_EXEC_HOSTUSER "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/export_stops_csv.sh
+++ b/export_stops_csv.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain all the data to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -20,4 +20,4 @@ mkdir -p "$WORK_DIR"/csv
 docker_exec "$CURRUSER" "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/export_stops_csv.sh
+++ b/export_stops_csv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -10,14 +10,14 @@ source "$(dirname "$0")/set_env_vars.sh"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 # Export csv file to output directory.
 OUTPUT_FILENAME="digiroad_stops.csv"
 
 mkdir -p "$WORK_DIR"/csv
 
-$DOCKER_EXEC_HOSTUSER "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
+docker_exec "$CURRUSER" "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/select_stops_as_csv.sql -v schema=$DB_SCHEMA_NAME_DIGIROAD -o /tmp/csv/$OUTPUT_FILENAME"
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/import_digiroad_shapefiles.sh
+++ b/import_digiroad_shapefiles.sh
@@ -69,7 +69,7 @@ done
 
 # Import "add_links" and "remove_links" layers from GeoPackage fixup file if it exists.
 if [ -f "$CWD"/fixup/digiroad/fixup.gpkg ]; then
-  OGR2OGR="exec ogr2ogr -f PostgreSQL \"PG:host=\$POSTGRES_PORT_5432_TCP_ADDR port=\$POSTGRES_PORT_5432_TCP_PORT dbname=$DB_NAME user=digiroad schemas=${DB_SCHEMA_NAME_DIGIROAD}\""
+  OGR2OGR="exec ogr2ogr -f PostgreSQL $OGR2OGR_PG_REF"
 
   docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
     sh -c "$OGR2OGR /tmp/gpkg/fixup.gpkg -nln fix_layer_link add_links"

--- a/import_digiroad_shapefiles.sh
+++ b/import_digiroad_shapefiles.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 AREA="UUSIMAA"
 

--- a/import_digiroad_shapefiles.sh
+++ b/import_digiroad_shapefiles.sh
@@ -41,7 +41,7 @@ docker kill "$DOCKER_CONTAINER_NAME" &> /dev/null || true
 docker rm -v "$DOCKER_CONTAINER_NAME" &> /dev/null || true
 
 # Create and start new Docker container.
-docker run --name "$DOCKER_CONTAINER_NAME" -p 127.0.0.1:21000:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -d "$DOCKER_IMAGE"
+docker run --name "$DOCKER_CONTAINER_NAME" -p 127.0.0.1:${DOCKER_CONTAINER_PORT}:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -d "$DOCKER_IMAGE"
 
 # Wait for PostgreSQL to start.
 docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT_LOCAL"

--- a/import_digiroad_shapefiles.sh
+++ b/import_digiroad_shapefiles.sh
@@ -109,4 +109,4 @@ docker_exec postgres "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/transform_dr_kaa
 docker_exec postgres "exec $PSQL -v ON_ERROR_STOP=1 -f /tmp/sql/create_mbtiles_schema.sql -v source_schema=$DB_SCHEMA_NAME_DIGIROAD -v schema=$DB_SCHEMA_NAME_MBTILES"
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/import_infra_network_csv.sh
+++ b/import_infra_network_csv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Reading connection parameters
 echo "Please fill in the connection parameters for the database to import the data to:"

--- a/import_infra_network_csv.sh
+++ b/import_infra_network_csv.sh
@@ -17,9 +17,9 @@ read -p "Password (default: adminpassword): " PGPASSWORD
 PGPASSWORD="${PGPASSWORD:-adminpassword}"
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Import dump from csv file.
 INPUT_FILENAME="infra_network_digiroad.csv"
-PGPASSWORD="${PGPASSWORD}" psql -h "${PGHOSTNAME}" -p "${PGPORT}" -U "${PGUSERNAME}" -d "${PGDATABASE}" \
-  -v ON_ERROR_STOP=1 -f ${CWD}/sql/import_infra_links_from_csv.sql -v csvfile="${WORK_DIR}/csv/${INPUT_FILENAME}"
+PGPASSWORD="$PGPASSWORD" psql -h "$PGHOSTNAME" -p "$PGPORT" -U "$PGUSERNAME" -d "$PGDATABASE" \
+  -v ON_ERROR_STOP=1 -f "$CWD"/sql/import_infra_links_from_csv.sql -v csvfile="${WORK_DIR}/csv/${INPUT_FILENAME}"

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -12,7 +12,7 @@ docker start "$DOCKER_CONTAINER_NAME"
 # Wait for PostgreSQL server to be ready.
 docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT"
 
-OGR_PG_SRC="PG:\"host=\$POSTGRES_PORT_5432_TCP_ADDR port=\$POSTGRES_PORT_5432_TCP_PORT user=digiroad dbname=$DB_NAME schemas=${DB_IMPORT_SCHEMA_NAME}\""
+OGR_PG_SRC="PG:\"host=\$POSTGRES_PORT_5432_TCP_ADDR port=\$POSTGRES_PORT_5432_TCP_PORT user=digiroad dbname=$DB_NAME schemas=${DB_SCHEMA_NAME_DIGIROAD}\""
 
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
   sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR_PG_SRC -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -12,16 +12,14 @@ docker start "$DOCKER_CONTAINER_NAME"
 # Wait for PostgreSQL server to be ready.
 docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT"
 
-OGR_PG_SRC="PG:\"host=\$POSTGRES_PORT_5432_TCP_ADDR port=\$POSTGRES_PORT_5432_TCP_PORT user=digiroad dbname=$DB_NAME schemas=${DB_SCHEMA_NAME_DIGIROAD}\""
+docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
+  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
 
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR_PG_SRC -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
+  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
 
 docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR_PG_SRC -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
-
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR_PG_SRC -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
+  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -10,16 +10,13 @@ source "$(dirname "$0")/set_env_vars.sh"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-docker exec "$DOCKER_CONTAINER_NAME" sh -c "$PG_WAIT"
+$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
 
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
+OGR2OGR="exec ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF"
 
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
-
-docker run --rm --link "$DOCKER_CONTAINER_NAME":postgres -v "$CWD"/fixup/digiroad:/tmp/gpkg "$DOCKER_IMAGE" \
-  sh -c "ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
+$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
+$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
+$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Stop on first error. Have meaningful error messages. Print each command to stdout.
-set -euxo pipefail
+set -euo pipefail
 
 # Source common environment variables.
 source "$(dirname "$0")/set_env_vars.sh"
@@ -10,13 +10,13 @@ source "$(dirname "$0")/set_env_vars.sh"
 docker start "$DOCKER_CONTAINER_NAME"
 
 # Wait for PostgreSQL server to be ready.
-$DOCKER_EXEC_POSTGRES "exec $PG_WAIT"
+docker_exec postgres "exec $PG_WAIT"
 
 OGR2OGR="exec ogr2ogr -f GPKG -overwrite /tmp/gpkg/fixup.gpkg $OGR2OGR_PG_REF"
 
-$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
-$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
-$DOCKER_EXEC_HOSTUSER "$OGR2OGR -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
+docker_exec "$CURRUSER" "$OGR2OGR -nlt LINESTRINGZM -nln add_links -dim XYZM -sql \"SELECT * FROM fix_layer_link\""
+docker_exec "$CURRUSER" "$OGR2OGR -nln add_stop_points -sql \"SELECT * FROM fix_layer_stop_point\""
+docker_exec "$CURRUSER" "$OGR2OGR -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
 
 # Stop Docker container.
 docker stop "$DOCKER_CONTAINER_NAME"

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Source common environment variables.
-source "$(cd "$(dirname "$0")"; pwd -P)/set_env_vars.sh"
+source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain required database tables to be exported.
 docker start "$DOCKER_CONTAINER_NAME"

--- a/rewrite_fixup_geopkg.sh
+++ b/rewrite_fixup_geopkg.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source "$(dirname "$0")/set_env_vars.sh"
 
 # Start Docker container. The container is expected to exist and contain required database tables to be exported.
-docker start "$DOCKER_CONTAINER_NAME"
+docker_start
 
 # Wait for PostgreSQL server to be ready.
 docker_exec postgres "exec $PG_WAIT"
@@ -19,4 +19,4 @@ docker_exec "$CURRUSER" "$OGR2OGR -nln add_stop_points -sql \"SELECT * FROM fix_
 docker_exec "$CURRUSER" "$OGR2OGR -nlt LINESTRINGZM -nln remove_links -dim XYZM -sql \"SELECT * FROM fix_layer_link_exclusion_geometry\""
 
 # Stop Docker container.
-docker stop "$DOCKER_CONTAINER_NAME"
+docker_stop

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -36,6 +36,14 @@ export PSQL="psql -h $DB_HOST -p $DB_PORT -U $DB_USERNAME -d $DB_NAME --no-passw
 CURRUSER=$(id -u):$(id -g)
 export CURRUSER
 
+docker_start() {
+  docker start "$DOCKER_CONTAINER_NAME"
+}
+
+docker_stop() {
+  docker stop "$DOCKER_CONTAINER_NAME"
+}
+
 print_and_run_cmd() {
   echo "+ $*"
   "$@"

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -12,6 +12,12 @@ export DOCKER_IMAGE="jore4/postgis-digiroad"
 export DOCKER_CONTAINER_NAME="jore4-postgis-digiroad"
 export DOCKER_CONTAINER_PORT="21000"
 
+export DOCKER_EXEC_POSTGRES="docker exec -u postgres $DOCKER_CONTAINER_NAME sh -c"
+# In Linux, UID/GID mapping provides correct permissions for files written inside
+# Docker container so that the Docker host user owns them.
+DOCKER_EXEC_HOSTUSER="docker exec -u $(id -u):$(id -g) $DOCKER_CONTAINER_NAME sh -c"
+export DOCKER_EXEC_HOSTUSER
+
 # Database details
 LOCAL_DB_NAME="digiroad"
 export DB_NAME="$LOCAL_DB_NAME"
@@ -20,13 +26,12 @@ export DB_SCHEMA_NAME_DIGIROAD="digiroad"
 export DB_SCHEMA_NAME_MBTILES="mbtiles"
 export DB_SCHEMA_NAME_ROUTING="routing"
 
-DB_HOST="\$POSTGRES_PORT_5432_TCP_ADDR"
-DB_PORT="\$POSTGRES_PORT_5432_TCP_PORT"
+DB_HOST="localhost"
+DB_PORT="5432"
 
 # Commands to run inside Docker container.
 export OGR2OGR_PG_REF="PG:\"host=$DB_HOST port=$DB_PORT dbname=$DB_NAME user=$DB_USERNAME schemas=$DB_SCHEMA_NAME_DIGIROAD\""
-export PGSQL2SHP="pgsql2shp -h \"$DB_HOST\" -p \"$DB_PORT\" -u $DB_USERNAME"
-export PG_DUMP="exec pg_dump -h \"$DB_HOST\" -p \"$DB_PORT\" -d $DB_NAME -U $DB_USERNAME --no-password"
-export PG_WAIT="exec /wait-pg.sh $DB_NAME \"$DB_HOST\" \"$DB_PORT\""
-export PG_WAIT_LOCAL="exec /wait-pg.sh $LOCAL_DB_NAME localhost 5432"
-export PSQL="exec psql -h \"$DB_HOST\" -p \"$DB_PORT\" -U $DB_USERNAME -d $DB_NAME --no-password"
+export PGSQL2SHP="pgsql2shp -h $DB_HOST -p $DB_PORT -u $DB_USERNAME"
+export PG_DUMP="pg_dump -h $DB_HOST -p $DB_PORT -d $DB_NAME -U $DB_USERNAME --no-password"
+export PG_WAIT="/wait-pg.sh $DB_NAME $DB_HOST $DB_PORT"
+export PSQL="psql -h $DB_HOST -p $DB_PORT -U $DB_USERNAME -d $DB_NAME --no-password"

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -12,9 +12,9 @@ export DOCKER_CONTAINER_NAME="jore4-postgis-digiroad"
 
 # Database details
 export DB_NAME="digiroad"
-export DB_IMPORT_SCHEMA_NAME="digiroad"
-export DB_MBTILES_SCHEMA_NAME="mbtiles"
-export DB_ROUTING_SCHEMA_NAME="routing"
+export DB_SCHEMA_NAME_DIGIROAD="digiroad"
+export DB_SCHEMA_NAME_MBTILES="mbtiles"
+export DB_SCHEMA_NAME_ROUTING="routing"
 
 # Commands to run inside Docker container.
 export PSQL="exec psql -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -U digiroad -d $DB_NAME --no-password"

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -5,10 +5,12 @@ CWD="$(cd "$(dirname "$0")" || exit; pwd -P)"
 export CWD
 export WORK_DIR="${CWD}/workdir"
 
+# shapefile encoding
 export SHP_ENCODING="UTF-8"
 
 export DOCKER_IMAGE="jore4/postgis-digiroad"
 export DOCKER_CONTAINER_NAME="jore4-postgis-digiroad"
+export DOCKER_CONTAINER_PORT="21000"
 
 # Database details
 export DB_NAME="digiroad"

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -13,13 +13,20 @@ export DOCKER_CONTAINER_NAME="jore4-postgis-digiroad"
 export DOCKER_CONTAINER_PORT="21000"
 
 # Database details
-export DB_NAME="digiroad"
+LOCAL_DB_NAME="digiroad"
+export DB_NAME="$LOCAL_DB_NAME"
+export DB_USERNAME="digiroad"
 export DB_SCHEMA_NAME_DIGIROAD="digiroad"
 export DB_SCHEMA_NAME_MBTILES="mbtiles"
 export DB_SCHEMA_NAME_ROUTING="routing"
 
+DB_HOST="\$POSTGRES_PORT_5432_TCP_ADDR"
+DB_PORT="\$POSTGRES_PORT_5432_TCP_PORT"
+
 # Commands to run inside Docker container.
-export PG_DUMP="exec pg_dump -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -d $DB_NAME -U digiroad --no-password"
-export PG_WAIT="exec /wait-pg.sh $DB_NAME \"\$POSTGRES_PORT_5432_TCP_ADDR\" \"\$POSTGRES_PORT_5432_TCP_PORT\""
-export PG_WAIT_LOCAL="exec /wait-pg.sh $DB_NAME localhost \"\$POSTGRES_PORT_5432_TCP_PORT\""
-export PSQL="exec psql -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -U digiroad -d $DB_NAME --no-password"
+export OGR2OGR_PG_REF="PG:\"host=$DB_HOST port=$DB_PORT dbname=$DB_NAME user=$DB_USERNAME schemas=$DB_SCHEMA_NAME_DIGIROAD\""
+export PGSQL2SHP="pgsql2shp -h \"$DB_HOST\" -p \"$DB_PORT\" -u $DB_USERNAME"
+export PG_DUMP="exec pg_dump -h \"$DB_HOST\" -p \"$DB_PORT\" -d $DB_NAME -U $DB_USERNAME --no-password"
+export PG_WAIT="exec /wait-pg.sh $DB_NAME \"$DB_HOST\" \"$DB_PORT\""
+export PG_WAIT_LOCAL="exec /wait-pg.sh $LOCAL_DB_NAME localhost 5432"
+export PSQL="exec psql -h \"$DB_HOST\" -p \"$DB_PORT\" -U $DB_USERNAME -d $DB_NAME --no-password"

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -12,12 +12,6 @@ export DOCKER_IMAGE="jore4/postgis-digiroad"
 export DOCKER_CONTAINER_NAME="jore4-postgis-digiroad"
 export DOCKER_CONTAINER_PORT="21000"
 
-export DOCKER_EXEC_POSTGRES="docker exec -u postgres $DOCKER_CONTAINER_NAME sh -c"
-# In Linux, UID/GID mapping provides correct permissions for files written inside
-# Docker container so that the Docker host user owns them.
-DOCKER_EXEC_HOSTUSER="docker exec -u $(id -u):$(id -g) $DOCKER_CONTAINER_NAME sh -c"
-export DOCKER_EXEC_HOSTUSER
-
 # Database details
 LOCAL_DB_NAME="digiroad"
 export DB_NAME="$LOCAL_DB_NAME"
@@ -35,3 +29,20 @@ export PGSQL2SHP="pgsql2shp -h $DB_HOST -p $DB_PORT -u $DB_USERNAME"
 export PG_DUMP="pg_dump -h $DB_HOST -p $DB_PORT -d $DB_NAME -U $DB_USERNAME --no-password"
 export PG_WAIT="/wait-pg.sh $DB_NAME $DB_HOST $DB_PORT"
 export PSQL="psql -h $DB_HOST -p $DB_PORT -U $DB_USERNAME -d $DB_NAME --no-password"
+
+# In Linux, UID/GID mapping for `docker exec` fixes ownership/permission issues
+# for files written inside Docker container in such a way that the Docker host
+# user owns the files.
+CURRUSER=$(id -u):$(id -g)
+export CURRUSER
+
+print_and_run_cmd() {
+  echo "+ $*"
+  "$@"
+}
+
+docker_exec() {
+  local USER="$1"
+  shift
+  print_and_run_cmd docker exec -u "$USER" "$DOCKER_CONTAINER_NAME" sh -c "$@"
+}

--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -19,7 +19,7 @@ export DB_SCHEMA_NAME_MBTILES="mbtiles"
 export DB_SCHEMA_NAME_ROUTING="routing"
 
 # Commands to run inside Docker container.
-export PSQL="exec psql -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -U digiroad -d $DB_NAME --no-password"
+export PG_DUMP="exec pg_dump -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -d $DB_NAME -U digiroad --no-password"
 export PG_WAIT="exec /wait-pg.sh $DB_NAME \"\$POSTGRES_PORT_5432_TCP_ADDR\" \"\$POSTGRES_PORT_5432_TCP_PORT\""
 export PG_WAIT_LOCAL="exec /wait-pg.sh $DB_NAME localhost \"\$POSTGRES_PORT_5432_TCP_PORT\""
-export PG_DUMP="exec pg_dump -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -d $DB_NAME -U digiroad --no-password"
+export PSQL="exec psql -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -U digiroad -d $DB_NAME --no-password"

--- a/util/create_additional_pgdump_tocs.sh
+++ b/util/create_additional_pgdump_tocs.sh
@@ -3,8 +3,8 @@
 PGDUMP_FILE="$1"
 PGDUMP_TOC="${PGDUMP_FILE}.list"
 
-if [[ ! -f "${PGDUMP_TOC}" ]]; then
-    echo "A pg_dump toc file not found: ${PGDUMP_TOC}"
+if [[ ! -f "$PGDUMP_TOC" ]]; then
+    echo "A pg_dump toc file not found: $PGDUMP_TOC"
     exit 1
 fi
 
@@ -17,11 +17,11 @@ set -euxo pipefail
 # map-matching backend. Public transport stops are also excluded.
 PGDUMP_TOC_ONLY_LINKS_NO_ENUMS="${PGDUMP_FILE}.no-enums.only-links.list"
 
-fgrep "TABLE DATA routing infrastructure_source " ${PGDUMP_TOC} > ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS}
-fgrep "TABLE DATA routing infrastructure_link " ${PGDUMP_TOC} >> ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS}
-fgrep "TABLE DATA routing infrastructure_link_vertices_pgr " ${PGDUMP_TOC} >> ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS}
-fgrep "TABLE DATA routing infrastructure_link_safely_traversed_by_vehicle_type " ${PGDUMP_TOC} >> ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS}
-fgrep "SEQUENCE SET routing infrastructure_link_vertices_pgr_id_seq " ${PGDUMP_TOC} >> ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS}
+grep -F "TABLE DATA routing infrastructure_source " "$PGDUMP_TOC" > "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS"
+grep -F "TABLE DATA routing infrastructure_link " "$PGDUMP_TOC" >> "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS"
+grep -F "TABLE DATA routing infrastructure_link_vertices_pgr " "$PGDUMP_TOC" >> "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS"
+grep -F "TABLE DATA routing infrastructure_link_safely_traversed_by_vehicle_type " "$PGDUMP_TOC" >> "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS"
+grep -F "SEQUENCE SET routing infrastructure_link_vertices_pgr_id_seq " "$PGDUMP_TOC" >> "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS"
 
 # When passing this toc file as an argument to `pg_restore` command, only data
 # is restored (no table definitions). Data for enumeration tables is excluded
@@ -29,5 +29,5 @@ fgrep "SEQUENCE SET routing infrastructure_link_vertices_pgr_id_seq " ${PGDUMP_T
 # map-matching backend.
 PGDUMP_TOC_NO_ENUMS="${PGDUMP_FILE}.no-enums.links-and-stops.list"
 
-cp ${PGDUMP_TOC_ONLY_LINKS_NO_ENUMS} ${PGDUMP_TOC_NO_ENUMS}
-fgrep "TABLE DATA routing public_transport_stop " ${PGDUMP_TOC} >> ${PGDUMP_TOC_NO_ENUMS}
+cp "$PGDUMP_TOC_ONLY_LINKS_NO_ENUMS" "$PGDUMP_TOC_NO_ENUMS"
+grep -F "TABLE DATA routing public_transport_stop " "$PGDUMP_TOC" >> "$PGDUMP_TOC_NO_ENUMS"


### PR DESCRIPTION
Give shell scripts a facelift by making code more concise.

Remove deprecated `docker run --link` calls.

In addition, the code can now be easily modified so that Digiroad data can be imported into a database other than the one in the repository's custom Docker container.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-digiroad-import/53)
<!-- Reviewable:end -->
